### PR TITLE
Enhance support for ‘zero’ line

### DIFF
--- a/Sources/DSFSparkline/DSFSparklineDataSource.swift
+++ b/Sources/DSFSparkline/DSFSparklineDataSource.swift
@@ -22,7 +22,7 @@
 //
 
 import CoreGraphics
-import Foundation
+import UIKit
 
 @objc public class DSFSparklineDataSource: NSObject {
 
@@ -81,6 +81,41 @@ public extension DSFSparklineDataSource {
 			self.notifyDataChange()
 		}
 	}
+    
+    /// The 'zero' line color for drawing the horizontal line. Should be in the range lowerBound ..< upperBound
+    @objc var zeroLineColor: UIColor {
+        get {
+            self.sparkline.zeroLineColor
+        }
+        set {
+            self.sparkline.zeroLineColor = newValue
+            self.notifyDataChange()
+        }
+    }
+    
+    /// The 'zero' line width for drawing the horizontal line.
+    @objc var zeroLineWidth: CGFloat {
+        get {
+            self.sparkline.zeroLineWidth
+        }
+        set {
+            self.sparkline.zeroLineWidth = newValue
+            self.notifyDataChange()
+        }
+    }
+
+    //    var zeroLineType: DSFSparklineZeroLineType = .dash
+    /// The 'zero' line type for drawing the horizontal line.
+    @objc var zeroLineStyle: [CGFloat] {
+        get {
+            self.sparkline.zeroLineStyle
+        }
+        set {
+            self.sparkline.zeroLineStyle = newValue
+            self.notifyDataChange()
+        }
+    }
+
 
 	/// Add a new value. If there are more values than the window size, the oldest value is discarded
 	@objc func push(value: CGFloat) -> Bool {

--- a/Sources/DSFSparkline/private/core/SparklineWindow.swift
+++ b/Sources/DSFSparkline/private/core/SparklineWindow.swift
@@ -21,7 +21,8 @@
 //  OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import Foundation
+import UIKit
+import CoreGraphics
 
 class SparklineWindow<T> where T: BinaryFloatingPoint {
 
@@ -64,7 +65,16 @@ class SparklineWindow<T> where T: BinaryFloatingPoint {
 	}
 
 	/// The 'zero' line for drawing the horizontal line. Should be in yRange
-	var zeroLineValue: CGFloat = 0.0
+    var zeroLineValue: CGFloat = 0.0
+
+    /// The 'zero' line color for drawing the horizontal line.
+    var zeroLineColor: UIColor = DSFColor.systemGray
+
+    /// The 'zero' line width for drawing the horizontal line.
+    var zeroLineWidth: CGFloat = 1.0
+
+    /// The style of the 'zero' line. Use [] to specify a solid line.
+    var zeroLineStyle: [CGFloat] = [1.0, 1.0]
 
 	/// Create a sparkline data window with an optional data range
 	/// - Parameters:

--- a/Sources/DSFSparkline/private/ui/DSFSparklineView.swift
+++ b/Sources/DSFSparkline/private/ui/DSFSparklineView.swift
@@ -72,6 +72,27 @@ import UIKit
 	/// Draw a dotted line at the zero point on the y-axis
 	@IBInspectable public var showZero: Bool = false
 
+    /// The color of the dotted line at the zero point on the y-axis
+    #if os(macOS)
+    @IBInspectable public var zeroLineColor: NSColor = NSColor.gray {
+        didSet {
+            self.colorDidChange()
+        }
+    }
+    #else
+    @IBInspectable public var zeroLineColor: UIColor = .systemGray {
+        didSet {
+            self.colorDidChange()
+        }
+    }
+    #endif
+
+    /// The width of the dotted line at the zero point on the y-axis
+    @IBInspectable public var zeroLineWidth: CGFloat = 1.0
+    
+    /// The style of the dotted line. Use [] to specify a solid line.
+    public var zeroLineStyle: [CGFloat] = [1.0, 1.0]
+
 	/// The size of the sparkline window
 	///
 	/// This member is purely IBDesignable display related
@@ -130,10 +151,10 @@ extension DSFSparklineView {
 
 			if let primary = NSGraphicsContext.current?.cgContext {
 				primary.usingGState { ctx in
-					let color = DSFColor.disabledControlTextColor
-					ctx.setLineWidth(1 / self.retinaScale())
+                    let color = dataSource.zeroLineColor
+                    ctx.setLineWidth(dataSource.zeroLineWidth / self.retinaScale())
 					ctx.setStrokeColor(color.cgColor)
-					ctx.setLineDash(phase: 0.0, lengths: [1, 1])
+                    ctx.setLineDash(phase: 0.0, lengths: dataSource.zeroLineStyle)
 					ctx.strokeLineSegments(between: [CGPoint(x: 0.0, y: zeroPos), CGPoint(x: self.bounds.width, y: zeroPos)])
 				}
 			}
@@ -152,10 +173,10 @@ extension DSFSparklineView {
 
 			if let primary = UIGraphicsGetCurrentContext() {
 				primary.usingGState { ctx in
-					let color = DSFColor.systemGray
-					ctx.setLineWidth(1 / self.retinaScale())
+                    let color = dataSource.zeroLineColor
+                    ctx.setLineWidth(dataSource.zeroLineWidth / self.retinaScale())
 					ctx.setStrokeColor(color.cgColor)
-					ctx.setLineDash(phase: 0.0, lengths: [1, 1])
+                    ctx.setLineDash(phase: 0, lengths: dataSource.zeroLineStyle)
 					ctx.strokeLineSegments(between: [CGPoint(x: 0.0, y: zeroPos), CGPoint(x: self.bounds.width, y: zeroPos)])
 				}
 			}


### PR DESCRIPTION
- Add `zeroLineColor` (type UIColor)
- Add `zeroLineWidth` (type CGFloat)
- Add `zeroLineType` (type [CGFloat])
- Fixed compiler issue. See https://github.com/dagronf/DSFSparkline/issues/1#issuecomment-766148115